### PR TITLE
add endpoint for refresh

### DIFF
--- a/src/modules/integrations/integrations.service.ts
+++ b/src/modules/integrations/integrations.service.ts
@@ -1015,10 +1015,10 @@ export class IntegrationsService {
         }
     }
 
-    async getValidAccessToken(
+    async getRefreshedOauthIntegration(
         integrationId: string,
         organizationId: string,
-    ): Promise<{ accessToken: string; integration: MCPIntegrationInterface }> {
+    ): Promise<MCPIntegrationInterface> {
         const integration = await this.getIntegrationById(
             integrationId,
             organizationId,
@@ -1039,17 +1039,15 @@ export class IntegrationsService {
                 id: integrationId,
             } as MCPIntegrationInterface & { id: string });
 
-            if (refreshed.authType === MCPIntegrationAuthType.OAUTH2) {
-                return {
-                    accessToken: refreshed.accessToken!,
-                    integration: refreshed,
-                };
+            if (refreshed.authType !== MCPIntegrationAuthType.OAUTH2) {
+                throw new Error(
+                    'Failed to refresh token: Invalid integration type after refresh',
+                );
             }
-            throw new Error(
-                'Failed to refresh token: Invalid integration type after refresh',
-            );
+
+            return refreshed;
         }
 
-        return { accessToken: integration.accessToken!, integration };
+        return integration;
     }
 }

--- a/src/modules/mcp/mcp.controller.ts
+++ b/src/modules/mcp/mcp.controller.ts
@@ -195,7 +195,18 @@ export class McpController {
     ) {
         return this.mcpService.finalizeOAuthIntegration(
             request.organizationId,
-            body
-        )
+            body,
+        );
+    }
+
+    @Get('integration/custom/oauth/:integrationId/refresh-token')
+    refreshOAuthToken(
+        @Req() request: FastifyRequest,
+        @Param('integrationId') integrationId: string,
+    ) {
+        return this.mcpService.refreshOauthIntegration(
+            request.organizationId,
+            integrationId,
+        );
     }
 }

--- a/src/modules/mcp/mcp.service.ts
+++ b/src/modules/mcp/mcp.service.ts
@@ -77,10 +77,7 @@ export class McpService {
                 (connection) => connection.integrationId === integration.id,
             );
 
-            if (
-                integration.provider === 'kodusmcp' &&
-                integration.isDefault
-            ) {
+            if (integration.provider === 'kodusmcp' && integration.isDefault) {
                 return {
                     ...integration,
                     isConnected: true,
@@ -564,5 +561,15 @@ export class McpService {
         });
 
         return result;
+    }
+
+    async refreshOauthIntegration(
+        organizationId: string,
+        integrationId: string,
+    ) {
+        return this.integrationsService.getRefreshedOauthIntegration(
+            integrationId,
+            organizationId,
+        );
     }
 }

--- a/src/modules/providers/custom/custom.provider.ts
+++ b/src/modules/providers/custom/custom.provider.ts
@@ -143,13 +143,11 @@ export class CustomProvider extends BaseProvider {
             }
 
             if (integration.authType === MCPIntegrationAuthType.OAUTH2) {
-                const { integration: refreshedIntegration } =
-                    await this.integrationsService.getValidAccessToken(
+                integration =
+                    await this.integrationsService.getRefreshedOauthIntegration(
                         integrationId,
                         organizationId,
                     );
-
-                integration = refreshedIntegration;
             }
 
             const client = new CustomClient(integration);
@@ -179,13 +177,11 @@ export class CustomProvider extends BaseProvider {
             }
 
             if (integration.authType === MCPIntegrationAuthType.OAUTH2) {
-                const { integration: refreshedIntegration } =
-                    await this.integrationsService.getValidAccessToken(
+                integration =
+                    await this.integrationsService.getRefreshedOauthIntegration(
                         config.integrationId,
                         config.organizationId,
                     );
-
-                integration = refreshedIntegration;
             }
 
             const client = new CustomClient(integration);


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces a new endpoint for refreshing OAuth tokens and refactors the underlying service logic for handling token validation.

**Key Changes:**

*   **New Endpoint:** Added `GET integration/custom/oauth/:integrationId/refresh-token` to the `McpController` to allow triggering a token refresh for a specific integration.
*   **Service Refactor:** Renamed `getValidAccessToken` to `getRefreshedOauthIntegration` in `IntegrationsService`. The method now returns the `MCPIntegrationInterface` object directly instead of wrapping it in an object with the access token.
*   **Provider Updates:** Updated `CustomProvider` to use the refactored service method when validating OAuth tokens.
*   **Logic Update:** Added `refreshOauthIntegration` to `McpService` to handle the logic for the new endpoint by delegating to the integrations service.
<!-- kody-pr-summary:end -->