### PR TITLE
fixed error start prod mcp manager

### DIFF
--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -2,7 +2,7 @@ module.exports = {
     apps: [
         {
             name: 'kodus-mcp-manager',
-            script: './dist/main.js',
+            script: './dist/src/main.js',
             instances: 1,
             autorestart: true,
 

--- a/scripts/fetch-env.qa.sh
+++ b/scripts/fetch-env.qa.sh
@@ -21,6 +21,15 @@ KEYS=(
     "/qa/kodus-mcp-manager/API_MCP_MANAGER_PG_DB_SCHEMA"
 
     "/qa/kodus-mcp-manager/API_MCP_MANAGER_ENCRYPTION_SECRET"
+
+    "/qa/kodus-mcp-manager/API_DOCS_ENABLED"
+    "/qa/kodus-mcp-manager/API_DOCS_PATH"
+    "/qa/kodus-mcp-manager/API_DOCS_SPEC_PATH"
+    "/qa/kodus-mcp-manager/API_DOCS_IP_ALLOWLIST"
+    "/qa/kodus-mcp-manager/API_DOCS_BASIC_USER"
+    "/qa/kodus-mcp-manager/API_DOCS_BASIC_PASS"
+    "/qa/kodus-mcp-manager/API_DOCS_SERVER_URLS"
+    "/qa/kodus-mcp-manager/API_DOCS_BASE_URL"  
 )
 
 # List of all keys you need


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request addresses an issue preventing the application from starting correctly in production environments and introduces configuration for API documentation.

Key changes include:
*   **Fixed application startup path**: Corrected the script path in `ecosystem.config.js` from `./dist/main.js` to `./dist/src/main.js` to ensure the `kodus-mcp-manager` application starts successfully.
*   **Added API documentation environment variables**: Introduced new environment variables in `scripts/fetch-env.qa.sh` to support the configuration of API documentation (e.g., Swagger) in the QA environment. These variables include settings for enabling documentation, defining paths, specifying IP allowlists, configuring basic authentication credentials, and setting server URLs.
<!-- kody-pr-summary:end -->