### PR TITLE
fixed load doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,7 +398,7 @@ POST /mcp/integration/kodusmcp
 
 ## 📚 OpenAPI / Swagger
 
-Swagger UI and OpenAPI JSON are exposed **only in development and qa environments** and require `API_DOCS_ENABLED=true`.
+Swagger UI and OpenAPI JSON are exposed when `API_DOCS_ENABLED=true`.
 
 ### 🔐 Basic Auth (required)
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -37,19 +37,17 @@ async function bootstrap() {
         }),
     );
 
-    const docsEnv = process.env.API_MCP_MANAGER_NODE_ENV || 'development';
-    const docsEnabledEnv = docsEnv === 'development' || docsEnv === 'qa';
-    const docsEnabledFlag =
-        (process.env.API_DOCS_ENABLED || '').toLowerCase() === 'true';
-    const docsUser = process.env.API_DOCS_BASIC_USER ?? '';
-    const docsPass = process.env.API_DOCS_BASIC_PASS ?? '';
-    const basicEnabled = !!docsUser && !!docsPass;
-    const docsEnabled = docsEnabledEnv && docsEnabledFlag && basicEnabled;
-    if (docsEnabledFlag && docsEnabledEnv && !basicEnabled) {
-        console.warn(
-            'API_DOCS_BASIC_USER/API_DOCS_BASIC_PASS required to enable docs. Docs disabled.',
-        );
-    }
+  const docsEnabledFlag =
+    (process.env.API_DOCS_ENABLED || '').toLowerCase() === 'true';
+  const docsUser = process.env.API_DOCS_BASIC_USER ?? '';
+  const docsPass = process.env.API_DOCS_BASIC_PASS ?? '';
+  const basicEnabled = !!docsUser && !!docsPass;
+  const docsEnabled = docsEnabledFlag && basicEnabled;
+  if (docsEnabledFlag && !basicEnabled) {
+    console.warn(
+      'API_DOCS_BASIC_USER/API_DOCS_BASIC_PASS required to enable docs. Docs disabled.',
+    );
+  }
     if (docsEnabled) {
         const rawDocsPath = process.env.API_DOCS_PATH || '/docs';
         const rawDocsSpecPath =


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces several changes related to the management and exposure of OpenAPI/Swagger documentation and environment variables.

Key changes include:

*   **Simplified Documentation Access Logic:** The application's logic for enabling OpenAPI/Swagger documentation has been simplified. Documentation is now enabled solely based on the `API_DOCS_ENABLED` flag being `true` and the presence of `API_DOCS_BASIC_USER` and `API_DOCS_BASIC_PASS` credentials, removing the previous restriction that limited exposure to only development and QA environments.
*   **Centralized Environment Variable Management:**
    *   Database connection settings (host, port, username, password, database) are now fetched from the `kodus-orchestrator` SSM path in the QA environment setup script, centralizing their configuration.
    *   Basic authentication credentials for documentation (`API_DOCS_BASIC_USER`, `API_DOCS_BASIC_PASS`) are also now sourced from the `kodus-orchestrator` SSM path.
*   **Explicit Documentation Disablement in QA:** The `fetch-env.qa.sh` script now explicitly sets `API_DOCS_ENABLED='false'` and provides default empty values for other documentation-related environment variables (path, spec path, IP allowlist, server URLs, base URL) in the `.env.qa` file. This ensures that documentation is disabled by default in the QA environment, overriding any centralized settings.
*   **Improved Environment Variable Handling:** The `fetch-env.qa.sh` script now wraps fetched environment variable values in single quotes, enhancing robustness for values that may contain special characters.
*   **Documentation Update:** The `README.md` has been updated to reflect that Swagger UI and OpenAPI JSON are exposed when `API_DOCS_ENABLED=true`, removing the previous mention of environment-specific restrictions.
<!-- kody-pr-summary:end -->