### PR TITLE
feat: split isProduction and SSL requirement

### DIFF
--- a/src/config/typeorm.config.ts
+++ b/src/config/typeorm.config.ts
@@ -21,8 +21,11 @@ for (const envVar of requiredEnvVars) {
 const isProduction =
     process.env.API_MCP_MANAGER_NODE_ENV === 'production' ||
     process.env.API_MCP_MANAGER_DATABASE_ENV === 'production';
+const disableSSL = process.env.API_DATABASE_DISABLE_SSL === 'true';
 
-const sslConfig = isProduction ? { rejectUnauthorized: false } : false;
+const useSSL = isProduction && !disableSSL;
+
+const sslConfig = useSSL ? { rejectUnauthorized: false } : false;
 
 const dataSourceConfig: DataSourceOptions = {
     type: 'postgres',


### PR DESCRIPTION
Continuation from https://github.com/kodustech/kodus-ai/pull/695

---

<!-- kody-pr-summary:start -->
Introduces a new environment variable, `API_DATABASE_DISABLE_SSL`, to allow for explicitly disabling SSL for database connections. Previously, SSL was automatically enabled when the application was detected as running in a production environment. This change decouples the SSL requirement from the production status, providing more granular control over database connection security.
<!-- kody-pr-summary:end -->